### PR TITLE
Allow passing additional query parameters for building authorize url

### DIFF
--- a/lib/vend/oauth2/auth_code.rb
+++ b/lib/vend/oauth2/auth_code.rb
@@ -17,8 +17,10 @@ module Vend
         @options = DEFAULT_OPTIONS.merge(options)
       end
 
-      def authorize_url
-        get_oauth2_client.auth_code.authorize_url(redirect_uri: redirect_uri)
+      def authorize_url(params = {})
+        params.merge!(redirect_uri: redirect_uri)
+
+        get_oauth2_client.auth_code.authorize_url(**params)
       end
 
       def token_from_code(code)

--- a/spec/vend/unit/oauth2/auth_code_spec.rb
+++ b/spec/vend/unit/oauth2/auth_code_spec.rb
@@ -15,8 +15,25 @@ RSpec.describe Vend::Oauth2::AuthCode do
   end
 
   describe '#authorize_url' do
-    it 'return url' do
-      expect(subject.authorize_url).to eq('https://secure.vendhq.com/connect?client_id=client_id&redirect_uri=redirect_uri&response_type=code')
+    let(:expected_base_url) do
+      'https://secure.vendhq.com/connect?client_id=client_id&redirect_uri=redirect_uri&response_type=code'
+    end
+
+    context 'when no additional parameters passed' do
+      subject { super().authorize_url }
+
+      it 'return url' do
+        is_expected.to eq(expected_base_url)
+      end
+    end
+
+    context 'when additional parameters passed' do
+      let(:state) { SecureRandom.hex }
+      subject { super().authorize_url(state: state) }
+
+      it 'returns url with additional parameters' do
+        is_expected.to eq("#{expected_base_url}&state=#{state}")
+      end
     end
   end
 


### PR DESCRIPTION
Allows passing through `state` parameter which is required now.

Usage:

```ruby
auth_code = Vend::Oauth2::AuthCode.new('store', 'client_id', 'secret', 'redirect_uri')

auth_code.authorize_url
# => "https://secure.vendhq.com/connect?client_id=client_id&redirect_uri=redirect_uri&response_type=code"

auth_code.authorize_url(state: 'UNIQUE_STATE_IDENTIFIER')
# => "https://secure.vendhq.com/connect?client_id=client_id&redirect_uri=redirect_uri&response_type=code&state=UNIQUE_STATE_IDENTIFIER"
```